### PR TITLE
Upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -8,18 +8,15 @@ on:
   pull_request:
     branches: [ master ]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
     - name: Install dependencies

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -4,15 +4,12 @@ on:
   push:
     branches: [ gh-pages ]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   lighthouse:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Wait for GitHub Pages to propagate
       run: sleep 60
     - name: Audit URLs using Lighthouse


### PR DESCRIPTION
## Summary
- `actions/checkout`: v4 → **v6** (Node.js 24 native)
- `actions/setup-dotnet`: v4 → **v5** (Node.js 24 native)
- Remove `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` workaround from both workflows — no longer needed

Fixes the deprecation warnings appearing in CI:
> Node.js 20 actions are deprecated... Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## Test plan
- [ ] Merge and verify `.NET Core` workflow runs green on next push to master
- [ ] Verify `Lighthouse` workflow runs on next gh-pages push

🤖 Generated with [Claude Code](https://claude.com/claude-code)