### PR TITLE
Fix Lighthouse workflow trigger

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,11 +1,15 @@
 name: Lighthouse
 
 on:
-  push:
-    branches: [ gh-pages ]
+  workflow_run:
+    workflows: [".NET Core"]
+    types: [completed]
+    branches: [master]
 
 jobs:
   lighthouse:
+    # Only run when the deploy workflow succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Problem

The Lighthouse workflow was set to trigger on `push: branches: [gh-pages]`, but it **never ran**. This is a known GitHub Actions restriction: when a workflow uses `GITHUB_TOKEN` to push to a branch (as the deploy step does), GitHub deliberately suppresses downstream workflow triggers on that branch to prevent infinite loops.

## Fix

Switch to `workflow_run` — fires after the `.NET Core` workflow completes on `master`, gated on `conclusion == 'success'` so Lighthouse only audits a successful deploy.

```
push to master
  → .NET Core workflow runs → deploys to gh-pages
    → workflow_run event fires
      → Lighthouse workflow runs (after 60s propagation wait)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)