### PR TITLE
Add Surge.sh PR preview deployments

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,69 @@
+name: Preview
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Generate site
+        run: dotnet run --configuration Release
+      - name: Index with Pagefind
+        run: npx pagefind --site output
+      - name: Deploy to Surge
+        env:
+          SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+        run: npx surge ./output petrsvihlik-pr-${{ github.event.pull_request.number }}.surge.sh
+      - name: Post preview URL comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = 'https://petrsvihlik-pr-${{ github.event.pull_request.number }}.surge.sh';
+            const marker = '<!-- surge-preview -->';
+            const body = `${marker}\n🚀 **Preview:** [${url}](${url})`;
+
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.data.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  teardown-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Teardown Surge preview
+        env:
+          SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+        run: npx surge teardown petrsvihlik-pr-${{ github.event.pull_request.number }}.surge.sh

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,11 +22,13 @@ jobs:
         run: dotnet run --configuration Release
       - name: Index with Pagefind
         run: npx pagefind --site output
+      - name: Install Surge
+        run: npm install -g surge
       - name: Deploy to Surge
         env:
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-        run: npx surge ./output petrsvihlik-pr-${{ github.event.pull_request.number }}.surge.sh
+        run: surge ./output petrsvihlik-pr-${{ github.event.pull_request.number }}.surge.sh
       - name: Post preview URL comment
         uses: actions/github-script@v7
         with:
@@ -62,8 +64,10 @@ jobs:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
+      - name: Install Surge
+        run: npm install -g surge
       - name: Teardown Surge preview
         env:
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-        run: npx surge teardown petrsvihlik-pr-${{ github.event.pull_request.number }}.surge.sh
+        run: surge teardown petrsvihlik-pr-${{ github.event.pull_request.number }}.surge.sh


### PR DESCRIPTION
## Summary

- Each PR gets a live preview at `https://petrsvihlik-pr-{N}.surge.sh`, automatically built and deployed on every push
- A comment is posted (and updated on subsequent pushes) with the preview URL
- The Surge deployment is torn down when the PR is closed/merged

## Setup required

Add two repository secrets before merging:
- `SURGE_LOGIN` — your Surge account email
- `SURGE_TOKEN` — output of `npx surge token`

Go to **Settings → Secrets and variables → Actions → New repository secret**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)