### PR TITLE
Fix deploy-preview CI for Dependabot PRs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy-preview:
-    if: github.event.action != 'closed'
+    if: github.event.action != 'closed' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,8 +7,11 @@ on:
 
 jobs:
   deploy-preview:
-    if: github.event.action != 'closed' && github.actor != 'dependabot[bot]'
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v5

--- a/PetrSvihlik.Com.csproj
+++ b/PetrSvihlik.Com.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="System.DirectoryServices.Protocols" Version="10.0.5" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.5" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PetrSvihlik.Com.csproj
+++ b/PetrSvihlik.Com.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="System.DirectoryServices.Protocols" Version="10.0.5" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.5" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.5" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Bumps `System.Security.Cryptography.Xml` from 10.0.5 → 10.0.6 (security patch from Dependabot PR #38)
- Fixes the `deploy-preview` workflow failing for Dependabot PRs by adding explicit `issues: write` / `pull-requests: write` permissions — Dependabot-triggered `pull_request` workflows receive a read-only `GITHUB_TOKEN` by default, which caused the preview URL comment step to 403

## Prerequisites

`SURGE_LOGIN` and `SURGE_TOKEN` must be added to **Settings → Secrets and variables → Dependabot** (in addition to the existing repo secrets) so the Surge deploy step can authenticate when triggered by Dependabot.

## Test plan

- [ ] Merge this PR — confirm `deploy-preview` passes on the Dependabot PR #38 after the Dependabot secrets are configured
- [ ] Verify a preview URL comment is posted on the PR

https://claude.ai/code/session_018BsvAZMR1V4p6qRAvtk82P