### PR TITLE
Fix preview comment for Dependabot PRs via workflow_run

### DIFF
--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -1,0 +1,53 @@
+name: Preview Comment
+
+on:
+  workflow_run:
+    workflows: [Preview]
+    types: [completed]
+
+jobs:
+  post-comment:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      actions: read
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          name: pr-number
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Post preview URL comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const prNumber = parseInt(fs.readFileSync('pr-number.txt', 'utf8').trim());
+            const url = `https://petrsvihlik-pr-${prNumber}.surge.sh`;
+            const marker = '<!-- surge-preview -->';
+            const body = `${marker}\n🚀 **Preview:** [${url}](${url})`;
+
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existing = comments.data.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,9 +9,6 @@ jobs:
   deploy-preview:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v5
@@ -32,36 +29,13 @@ jobs:
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
         run: surge ./output petrsvihlik-pr-${{ github.event.pull_request.number }}.surge.sh
-      - name: Post preview URL comment
-        uses: actions/github-script@v7
+      - name: Save PR number
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+      - uses: actions/upload-artifact@v7
         with:
-          script: |
-            const url = 'https://petrsvihlik-pr-${{ github.event.pull_request.number }}.surge.sh';
-            const marker = '<!-- surge-preview -->';
-            const body = `${marker}\n🚀 **Preview:** [${url}](${url})`;
-
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const existing = comments.data.find(c => c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+          name: pr-number
+          path: pr-number.txt
+          retention-days: 1
 
   teardown-preview:
     if: github.event.action == 'closed'


### PR DESCRIPTION
## Problem

GitHub hard-limits the `GITHUB_TOKEN` to read-only for Dependabot-triggered `pull_request` events. The `permissions` block cannot override this, so the step that posts the Surge preview URL comment was consistently failing with 403.

## Solution

Split the comment step into a dedicated `workflow_run` workflow. Workflows triggered by `workflow_run` always run in the base branch context with a full write token, regardless of who opened the original PR.

## Changes

- **`preview.yml`** — removed the comment step; saves the PR number as a short-lived artifact after the Surge deploy
- **`preview-comment.yml`** (new) — triggered after `Preview` completes successfully; downloads the artifact and posts/updates the Surge preview URL comment with `issues: write` permission

https://claude.ai/code/session_018BsvAZMR1V4p6qRAvtk82P